### PR TITLE
Force recreation of menu, regardless of language

### DIFF
--- a/fbreader/app/src/main/java/org/geometerplus/android/fbreader/FBReader.java
+++ b/fbreader/app/src/main/java/org/geometerplus/android/fbreader/FBReader.java
@@ -385,6 +385,7 @@ public final class FBReader extends FBReaderMainActivity implements ZLApplicatio
 	public void onOptionsMenuClosed(Menu menu) {
 		super.onOptionsMenuClosed(menu);
 		setStatusBarVisible(false);
+		invalidateOptionsMenu();
 	}
 
 	@Override
@@ -871,9 +872,6 @@ public final class FBReader extends FBReaderMainActivity implements ZLApplicatio
 
 	private void setupMenu(Menu menu) {
 		final String menuLanguage = ZLResource.getLanguageOption().getValue();
-		if (menuLanguage.equals(myMenuLanguage)) {
-			return;
-		}
 		myMenuLanguage = menuLanguage;
 
 		menu.clear();

--- a/fbreader/app/src/main/java/org/geometerplus/android/fbreader/FBReader.java
+++ b/fbreader/app/src/main/java/org/geometerplus/android/fbreader/FBReader.java
@@ -385,6 +385,7 @@ public final class FBReader extends FBReaderMainActivity implements ZLApplicatio
 	public void onOptionsMenuClosed(Menu menu) {
 		super.onOptionsMenuClosed(menu);
 		setStatusBarVisible(false);
+		// Solution for issue on Android 14 (SDK34) where the menu shows only once after first start. Note also the change in the setupMenu below.
 		invalidateOptionsMenu();
 	}
 
@@ -872,6 +873,12 @@ public final class FBReader extends FBReaderMainActivity implements ZLApplicatio
 
 	private void setupMenu(Menu menu) {
 		final String menuLanguage = ZLResource.getLanguageOption().getValue();
+		// Solution for issue on Android 14 (SDK34) where the menu shows only once after first start. Note also the invalidateOptionsMenu change above.
+		/*
+		if (menuLanguage.equals(myMenuLanguage)) {
+			return;
+		}
+  		*/
 		myMenuLanguage = menuLanguage;
 
 		menu.clear();


### PR DESCRIPTION
Din SDK-ul de Android (clasa PhoneWindow) am remarcat că se dă refresh la meniu doar dacă este deschis în expanded mode, ceea ce nu se întâmplă în cazul nostru, ceea ce înseamnă că nu se va mai popula meniul cu iteme. 
Lista de iteme din meniu se va goli când se închide, iar, pentru că limba meniului este aceeași cu limba sistemului, nu se va mai crea încă o dată. Un "workaround" ar fi să forțăm recrearea meniului de fiecare dată când se deschide.
Funcția invalidateOptionsMenu() indică faptul că trebuie repopulată lista.